### PR TITLE
Fixed an error in the behavior of Node creation.

### DIFF
--- a/Assets/FigmaImporter/Editor/FigmaNodeGenerator.cs
+++ b/Assets/FigmaImporter/Editor/FigmaNodeGenerator.cs
@@ -1,9 +1,9 @@
 ﻿using System;
+using System.IO;
 using System.Threading.Tasks;
 using TMPro;
 using UnityEditor;
 using UnityEngine;
-using UnityEngine.Assertions;
 using UnityEngine.UI;
 
 namespace FigmaImporter.Editor
@@ -12,7 +12,7 @@ namespace FigmaImporter.Editor
     {
         Vector2 offset = Vector2.zero;
         private RectTransform root = null;
-        private FigmaImporter _importer;
+        private readonly FigmaImporter _importer;
 
         public FigmaNodeGenerator(FigmaImporter importer)
         {
@@ -24,6 +24,9 @@ namespace FigmaImporter.Editor
             FigmaNodesProgressInfo.CurrentNode ++;
             FigmaNodesProgressInfo.CurrentInfo = "Node generation in progress";
             FigmaNodesProgressInfo.ShowProgress(0f);
+            
+            //RendersFolderの有無の確認
+            GenerateRenderSaveFolder(_importer.GetRendersFolderPath());
             
             var boundingBox = node.absoluteBoundingBox;
             bool isParentCanvas = false;
@@ -340,10 +343,18 @@ namespace FigmaImporter.Editor
 
         public GameObject FindCanvas()
         {
-            var obj = GameObject.FindObjectOfType<Canvas>().gameObject;
-            if (obj == null)
-                obj = GenerateCanvas();
-            return obj;
+            var obj = GameObject.FindObjectOfType<Canvas>();
+            return obj != null ? obj.gameObject : GenerateCanvas();
+        }
+
+        private static void GenerateRenderSaveFolder(string path)
+        {
+            var fullPath = Path.Combine(Application.dataPath, path);
+            if (Directory.Exists(fullPath))
+            {
+                return;
+            }
+            Directory.CreateDirectory(fullPath);
         }
     }
 }


### PR DESCRIPTION
## fix
* fix RendersPath does not save the material if there is no Folder.
* Fix occurs when there is no Canvas in the scene.

## Remarks
Thank you for making a great plugin.
Thank you very much.
I immediately tried to run it on my end, but it gave me errors when there was no folder or canvas, so I fixed it.
Thank you very much for your help.